### PR TITLE
本番環境のDB設定の変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -53,6 +53,5 @@ test:
 #
 production:
   <<: *default
-  database: LinguaShare_production
-  username: LinguaShare
-  password: <%= ENV['LINGUASHARE_DATABASE_PASSWORD'] %>
+  adapter: postgresql
+  url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
## WHY
本番環境で一部機能（会員登録）が動作しないため.
再度カリキュラムとコードを照らし合わせたところ、差異があった。

## WHAT
本番環境のDB設定を更新する。